### PR TITLE
[Issue 1] Implement `Display` trait for `ERD`

### DIFF
--- a/src/erd/entity.rs
+++ b/src/erd/entity.rs
@@ -2,6 +2,8 @@
 // Entity struct and implementation
 // ==================================================================
 
+use std::fmt;
+
 pub struct Entity {
     /// The id for the entity in the ERD.
     ///
@@ -40,6 +42,18 @@ impl Entity {
     pub fn add_attribute(mut self, attribute: Attribute) -> Self {
         self.attributes.push(attribute);
         self
+    }
+}
+
+impl fmt::Display for Entity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // format entity id
+        let mut entity_str = format!("{}", self.id);
+        // format the alias if it exists
+        if let Some(alias) = self.alias.as_deref() {
+            entity_str += &format!("[\"{}\"]", alias);
+        }
+        write!(f, "{}", entity_str)
     }
 }
 
@@ -82,11 +96,59 @@ impl Attribute {
         self.key.is_unique = true;
         self
     }
+
+    pub fn has_constraints(&self) -> bool {
+        self.key.is_primary || self.key.is_foreign || self.key.is_unique
+    }
+}
+
+impl fmt::Display for Attribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // format the required fields
+        let mut attr_str = format!("{} {}", self.attr_type, self.name);
+        // optionally add key constraints
+        if self.has_constraints() {
+            attr_str += &format!(" {}", self.key);
+        }
+        // optionally add comment
+        if let Some(comment) = self.comment.as_deref() {
+            attr_str += &format!(" \"{}\"", comment);
+        }
+        write!(f, "{}", attr_str)
+    }
 }
 
 // ==================================================================
 // KeyConstraints struct and implementation
 // ==================================================================
+
+#[derive(Debug)]
+enum ConstraintCombo {
+    None,
+    PrimaryKey,
+    ForeignKey,
+    UniqueKey,
+    PrimaryForeignKey,
+    PrimaryUniqueKey,
+    ForeignUniqueKey,
+    PrimaryForeignUniqueKey,
+}
+
+impl ConstraintCombo {
+    fn from_bools(is_primary: bool, is_foreign: bool, is_unique: bool) -> Self {
+        match (is_primary, is_foreign, is_unique) {
+            (false, false, false) => ConstraintCombo::None,
+            (true, false, false) => ConstraintCombo::PrimaryKey,
+            (false, true, false) => ConstraintCombo::ForeignKey,
+            (false, false, true) => ConstraintCombo::UniqueKey,
+            (true, true, false) => ConstraintCombo::PrimaryForeignKey,
+            (true, false, true) => ConstraintCombo::PrimaryUniqueKey,
+            (false, true, true) => ConstraintCombo::ForeignUniqueKey,
+            (true, true, true) => ConstraintCombo::PrimaryForeignUniqueKey,
+        }
+    }
+}
+
 pub struct KeyConstraints {
     pub is_primary: bool,
     pub is_foreign: bool,
@@ -100,6 +162,28 @@ impl KeyConstraints {
             is_unique: false,
         }
     }
+
+    fn to_combo(&self) -> ConstraintCombo {
+        ConstraintCombo::from_bools(self.is_primary, self.is_foreign, self.is_unique)
+    }
+}
+
+impl fmt::Display for KeyConstraints {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // format the required fields
+        let key_str = match self.to_combo() {
+            ConstraintCombo::None => "",
+            ConstraintCombo::PrimaryKey => "PK",
+            ConstraintCombo::ForeignKey => "FK",
+            ConstraintCombo::UniqueKey => "UK",
+            ConstraintCombo::PrimaryForeignKey => "PK, FK",
+            ConstraintCombo::PrimaryUniqueKey => "PK, UK",
+            ConstraintCombo::ForeignUniqueKey => "FK, UK",
+            ConstraintCombo::PrimaryForeignUniqueKey => "PK, FK, UK",
+        };
+        // optionally add key constraints
+        write!(f, "{}", key_str)
+    }
 }
 
 // ==================================================================
@@ -110,7 +194,10 @@ impl KeyConstraints {
 mod tests {
     use super::*;
 
-    const ENTITY_ID: &str = "PRODUCT";
+    const ENTITY_ID: &str = "ALBUM";
+    const ALIAS: &str = "album_table";
+    const ATTR_NAME: &str = "title";
+    const ATTR_TYPE: &str = "string";
 
     // =========================
     // Entity tests
@@ -129,27 +216,41 @@ mod tests {
 
         #[test]
         fn test_create_with_alias() {
-            // arrange
-            let alias = "product_table";
             // act
-            let entity = Entity::new(ENTITY_ID).with_alias(alias);
+            let entity = Entity::new(ENTITY_ID).with_alias(ALIAS);
             // assert
-            assert_eq!(entity.alias, Some(alias.to_string()));
+            assert_eq!(entity.alias, Some(ALIAS.to_string()));
         }
 
         #[test]
         fn test_add_attribute() {
-            // arrange
-            let alias = "product_table";
-            let attr_type = "string";
-            let attr_name = "product_id";
             // act
-            let entity = Entity::new(ENTITY_ID)
-                .with_alias(alias)
-                .add_attribute(Attribute::new(attr_type, attr_name));
+            let entity = Entity::new(ENTITY_ID).add_attribute(Attribute::new(ATTR_TYPE, ATTR_NAME));
             // assert
             assert_eq!(entity.attributes.len(), 1); // entity has one attribute
-            assert_eq!(entity.attributes[0].name, attr_name); // attr name matches
+            assert_eq!(entity.attributes[0].name, ATTR_NAME); // attr name matches
+        }
+
+        #[test]
+        fn test_display_without_attributes_or_alias() {
+            // arrange
+            let entity = Entity::new(ENTITY_ID);
+            let wanted = ENTITY_ID;
+            // act
+            let got = entity.to_string();
+            // assert
+            assert_eq!(got, wanted);
+        }
+
+        #[test]
+        fn test_display_with_alias() {
+            // arrange
+            let entity = Entity::new(ENTITY_ID).with_alias(ALIAS);
+            let wanted = format!("ALBUM[\"album_table\"]");
+            // act
+            let got = entity.to_string();
+            // assert
+            assert_eq!(got, wanted);
         }
     }
 
@@ -160,14 +261,11 @@ mod tests {
         use super::*;
         #[test]
         fn test_create_without_comment_or_key_constraints() {
-            // arrange
-            let attr_type: &str = "string";
-            let attr_name: &str = "product_id";
             // act
-            let attr = Attribute::new(attr_type, attr_name);
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME);
             // assert
-            assert_eq!(attr.attr_type, attr_type);
-            assert_eq!(attr.name, attr_name);
+            assert_eq!(attr.attr_type, ATTR_TYPE);
+            assert_eq!(attr.name, ATTR_NAME);
             assert_eq!(attr.key.is_primary, false);
             assert_eq!(attr.key.is_foreign, false);
             assert_eq!(attr.key.is_unique, false);
@@ -176,7 +274,7 @@ mod tests {
         #[test]
         fn test_create_as_primary_key() {
             // act
-            let attr = Attribute::new("string", "product_id").as_primary_key();
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME).as_primary_key();
             // assert
             assert_eq!(attr.key.is_primary, true);
         }
@@ -184,7 +282,7 @@ mod tests {
         #[test]
         fn test_create_as_foreign_key() {
             // act
-            let attr = Attribute::new("string", "product_id").as_foreign_key();
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME).as_foreign_key();
             // assert
             assert_eq!(attr.key.is_foreign, true);
         }
@@ -192,7 +290,7 @@ mod tests {
         #[test]
         fn test_create_as_unique() {
             // act
-            let attr = Attribute::new("string", "product_id").as_unique();
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME).as_unique();
             // assert
             assert_eq!(attr.key.is_unique, true);
         }
@@ -202,9 +300,57 @@ mod tests {
             // arrange
             let comment = "Unique identifier for the product";
             // act
-            let attr = Attribute::new("string", "product_id").with_comment(comment);
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME).with_comment(comment);
             // assert
             assert_eq!(attr.comment, Some(comment.to_string()));
+        }
+
+        #[test]
+        fn test_display_without_key_or_comment() {
+            // arrange
+            let wanted = format!("{ATTR_TYPE} {ATTR_NAME}");
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME);
+            // act
+            let got = attr.to_string();
+            // assert
+            assert_eq!(got, wanted)
+        }
+
+        #[test]
+        fn test_display_with_one_key_constraint() {
+            // arrange
+            let wanted = format!("{ATTR_TYPE} {ATTR_NAME} PK");
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME).as_primary_key();
+            // act
+            let got = attr.to_string();
+            // assert
+            assert_eq!(got, wanted)
+        }
+
+        #[test]
+        fn test_display_with_multiple_key_constraints() {
+            // arrange
+            let wanted = format!("{ATTR_TYPE} {ATTR_NAME} PK, FK, UK");
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME)
+                .as_primary_key()
+                .as_foreign_key()
+                .as_unique();
+            // act
+            let got = attr.to_string();
+            // assert
+            assert_eq!(got, wanted)
+        }
+
+        #[test]
+        fn test_display_with_comment() {
+            // arrange
+            let comment = "comment about album";
+            let wanted = format!("{ATTR_TYPE} {ATTR_NAME} \"{comment}\"");
+            let attr = Attribute::new(ATTR_TYPE, ATTR_NAME).with_comment(comment);
+            // act
+            let got = attr.to_string();
+            // assert
+            assert_eq!(got, wanted)
         }
     }
 }

--- a/src/erd/entity.rs
+++ b/src/erd/entity.rs
@@ -53,6 +53,17 @@ impl fmt::Display for Entity {
         if let Some(alias) = self.alias.as_deref() {
             entity_str += &format!("[\"{}\"]", alias);
         }
+        // format the attributes if they exist
+        if self.attributes.len() > 0 {
+            // append an opening bracket on the same line as the entity id
+            entity_str += " {";
+            // append each attribute to a new, indented line
+            for attr in &self.attributes {
+                entity_str += &format!("\n    {}", attr.to_string())
+            }
+            // append a final closing bracket on its own line
+            entity_str += "\n}";
+        }
         write!(f, "{}", entity_str)
     }
 }
@@ -104,13 +115,13 @@ impl Attribute {
 
 impl fmt::Display for Attribute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // format the required fields
+        // format the attribute type and name
         let mut attr_str = format!("{} {}", self.attr_type, self.name);
-        // optionally add key constraints
+        // format key constraints if any exist
         if self.has_constraints() {
             attr_str += &format!(" {}", self.key);
         }
-        // optionally add comment
+        // format the comment if one exists
         if let Some(comment) = self.comment.as_deref() {
             attr_str += &format!(" \"{}\"", comment);
         }
@@ -246,7 +257,27 @@ mod tests {
         fn test_display_with_alias() {
             // arrange
             let entity = Entity::new(ENTITY_ID).with_alias(ALIAS);
-            let wanted = format!("ALBUM[\"album_table\"]");
+            let wanted = "ALBUM[\"album_table\"]";
+            // act
+            let got = entity.to_string();
+            // assert
+            assert_eq!(got, wanted);
+        }
+
+        #[test]
+        fn test_display_with_multiple_attributes() {
+            // arrange
+            let attr_type = "integer";
+            let attr_name = "album_id";
+            let entity = Entity::new(ENTITY_ID)
+                .add_attribute(Attribute::new(attr_type, attr_name))
+                .add_attribute(Attribute::new(ATTR_TYPE, ATTR_NAME));
+            let wanted = concat!(
+                "ALBUM {\n",
+                "    integer album_id\n",
+                "    string title\n",
+                "}"
+            );
             // act
             let got = entity.to_string();
             // assert

--- a/src/erd/mod.rs
+++ b/src/erd/mod.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
+use std::fmt;
+
+use utils::Indent;
 
 pub mod entity;
 pub mod relationship;
+pub mod utils;
 
 // ==================================================================
 // EntityId struct and implementation
@@ -40,6 +44,21 @@ impl ERD {
             entities: HashMap::new(),
             relationships: Vec::new(),
         }
+    }
+}
+// implement the Display trait
+impl fmt::Display for ERD {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // initialize the erDiagram
+        let mut erd_str = "erDiagram".to_string();
+        // append entities if the ERD has them
+        if self.entities.len() > 0 {
+            // add each entity to new, indented line
+            for entity in self.entities.values() {
+                erd_str += &format!("\n{}", entity.to_string().indent(4));
+            }
+        }
+        write!(f, "{}", erd_str)
     }
 }
 
@@ -205,6 +224,42 @@ mod tests {
             // assert
             assert_eq!(erd.relationships.len(), 1);
             assert_eq!(erd.entities.len(), 2);
+        }
+
+        #[test]
+        fn display_empty_diagram() {
+            // arrange
+            let wanted = "erDiagram";
+            let erd = ERD::new();
+            // act
+            let got = erd.to_string();
+            // assert
+            assert_eq!(got, wanted)
+        }
+
+        #[test]
+        fn display_erd_with_entities_and_their_attributes() {
+            // arrange
+            let attr_type = "string";
+            let erd = ERD::new()
+                .with_entity(
+                    entity::Entity::new(ALBUM_ID)
+                        .add_attribute(entity::Attribute::new(attr_type, "foo"))
+                        .add_attribute(entity::Attribute::new(attr_type, "bar")),
+                )
+                .with_entity(entity::Entity::new(SONG_ID));
+            let album_wanted = concat!(
+                "    ALBUM {\n",
+                "        string foo\n",
+                "        string bar\n",
+                "    }",
+            );
+            let song_wanted = "SONG";
+            // act
+            let got = erd.to_string();
+            // assert
+            assert!(got.contains(album_wanted));
+            assert!(got.contains(song_wanted));
         }
     }
 }

--- a/src/erd/mod.rs
+++ b/src/erd/mod.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use utils::Indent;
-
 pub mod entity;
 pub mod relationship;
 pub mod utils;
@@ -46,17 +44,21 @@ impl ERD {
         }
     }
 }
+
 // implement the Display trait
 impl fmt::Display for ERD {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // initialize the erDiagram
         let mut erd_str = "erDiagram".to_string();
+
         // append entities if the ERD has them
         if self.entities.len() > 0 {
-            // add each entity to new, indented line
-            for entity in self.entities.values() {
-                erd_str += &format!("\n{}", entity.to_string().indent(4));
-            }
+            erd_str = utils::append_items(erd_str, self.entities.values(), "Entities", 4)
+        }
+
+        // append relationships if the ERD has them
+        if self.relationships.len() > 0 {
+            erd_str = utils::append_items(erd_str, &self.relationships, "Relationships", 4)
         }
         write!(f, "{}", erd_str)
     }
@@ -260,6 +262,35 @@ mod tests {
             // assert
             assert!(got.contains(album_wanted));
             assert!(got.contains(song_wanted));
+        }
+
+        #[test]
+        fn display_erd_with_relationships() {
+            // arrange
+            let artist_id = "ARTIST";
+            let erd = ERD::new()
+                .with_relationship(relationship::Relationship::new(
+                    ALBUM_ID,
+                    SONG_ID,
+                    relationship::Cardinality::ExactlyOne,
+                    relationship::Cardinality::OneOrMore,
+                ))
+                .with_relationship(
+                    relationship::Relationship::new(
+                        artist_id,
+                        ALBUM_ID,
+                        relationship::Cardinality::OneOrMore,
+                        relationship::Cardinality::OneOrMore,
+                    )
+                    .as_non_identifying(),
+                );
+            let album_song = "ALBUM ||--|{ SONG\n";
+            let artist_album = "ARTIST }|..|{ ALBUM";
+            // act
+            let got = erd.to_string();
+            // assert
+            assert!(got.contains(album_song));
+            assert!(got.contains(artist_album));
         }
     }
 }

--- a/src/erd/relationship.rs
+++ b/src/erd/relationship.rs
@@ -1,9 +1,39 @@
+use core::fmt;
+
 #[derive(PartialEq, Debug)]
 pub enum Cardinality {
     ZeroOrOne,
     ExactlyOne,
-    OneOrMore,
     ZeroOrMore,
+    OneOrMore,
+}
+enum Direction {
+    Left,
+    Right,
+}
+
+impl Cardinality {
+    // Combines Cardinality and Direction to format the relationship join symbol
+    fn fmt_with_direction(&self, dir: Direction) -> String {
+        match (self, dir) {
+            // formatting left_cardinality
+            (Cardinality::ZeroOrOne, Direction::Left) => "|o".to_string(),
+            (Cardinality::ExactlyOne, Direction::Left) => "||".to_string(),
+            (Cardinality::ZeroOrMore, Direction::Left) => "}o".to_string(),
+            (Cardinality::OneOrMore, Direction::Left) => "}|".to_string(),
+            // formatting right_cardinality
+            (Cardinality::ZeroOrOne, Direction::Right) => "o|".to_string(),
+            (Cardinality::ExactlyOne, Direction::Right) => "||".to_string(),
+            (Cardinality::ZeroOrMore, Direction::Right) => "o{".to_string(),
+            (Cardinality::OneOrMore, Direction::Right) => "|{".to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for Cardinality {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.fmt_with_direction(Direction::Right))
+    }
 }
 
 /// Represents relationships between entities in an ERD.
@@ -73,6 +103,33 @@ impl Relationship {
     }
 }
 
+impl fmt::Display for Relationship {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // format the left and right ends based on their cardinality
+        let left_str = format!(
+            "{} {}",
+            self.left_id.as_str(),
+            self.left_cardinality.fmt_with_direction(Direction::Left)
+        );
+        let right_str = format!(
+            "{} {}",
+            self.right_cardinality.fmt_with_direction(Direction::Right),
+            self.right_id.as_str()
+        );
+        // format the relationship as a solid or dashed line
+        let mut relationship_str = if self.is_identifying {
+            format!("{left_str}--{right_str}") // solid line
+        } else {
+            format!("{left_str}..{right_str}") // dashed line
+        };
+        // append the label if the relationship has one
+        if let Some(label) = self.label.as_deref() {
+            relationship_str += &format!(" : \"{}\"", label);
+        }
+        write!(f, "{}", relationship_str)
+    }
+}
+
 // =========================
 // EntityId tests
 // =========================
@@ -82,8 +139,8 @@ mod tests {
     use super::super::*;
     use super::*;
 
-    const ALBUM_ID: &str = "PRODUCT";
-    const SONG_ID: &str = "PRODUCT";
+    const ALBUM_ID: &str = "ALBUM";
+    const SONG_ID: &str = "SONG";
 
     #[test]
     fn test_that_entity_ids_with_same_string_are_equal() {
@@ -99,5 +156,40 @@ mod tests {
         assert_eq!(relationship.right_id, EntityId::from(SONG_ID));
         assert_eq!(relationship.left_cardinality, Cardinality::ExactlyOne);
         assert_eq!(relationship.right_cardinality, Cardinality::OneOrMore);
+    }
+
+    #[test]
+    fn test_display_identifying_without_a_label() {
+        // arrange
+        let relationship = Relationship::new(
+            ALBUM_ID,
+            SONG_ID,
+            Cardinality::ZeroOrOne,
+            Cardinality::ZeroOrMore,
+        );
+        let wanted = "ALBUM |o--o{ SONG";
+        // act
+        let got = relationship.to_string();
+        // assert
+        assert_eq!(got, wanted);
+    }
+
+    #[test]
+    fn test_display_non_identifying_with_a_label() {
+        // arrange
+        let label = "includes";
+        let relationship = Relationship::new(
+            ALBUM_ID,
+            SONG_ID,
+            Cardinality::ExactlyOne,
+            Cardinality::OneOrMore,
+        )
+        .as_non_identifying()
+        .with_label(label);
+        let wanted = "ALBUM ||..|{ SONG : \"includes\"";
+        // act
+        let got = relationship.to_string();
+        // assert
+        assert_eq!(got, wanted);
     }
 }

--- a/src/erd/utils.rs
+++ b/src/erd/utils.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 pub trait Indent {
     fn indent(&self, size: usize) -> String;
 }
@@ -16,4 +18,17 @@ impl Indent for String {
     fn indent(&self, size: usize) -> String {
         self.as_str().indent(size)
     }
+}
+
+pub fn append_items<T, I>(mut curr_str: String, items: T, note: &str, indent: usize) -> String
+where
+    T: IntoIterator<Item = I>,
+    I: fmt::Display,
+{
+    curr_str += &format!("\n{}%% {} start", " ".repeat(indent), note);
+    for item in items.into_iter() {
+        curr_str += &format!("\n{}", &item.to_string().indent(indent));
+    }
+    curr_str += &format!("\n{}%% {} end", " ".repeat(indent), note);
+    curr_str
 }

--- a/src/erd/utils.rs
+++ b/src/erd/utils.rs
@@ -1,0 +1,19 @@
+pub trait Indent {
+    fn indent(&self, size: usize) -> String;
+}
+
+impl Indent for str {
+    fn indent(&self, size: usize) -> String {
+        let indentation = " ".repeat(size);
+        self.lines()
+            .map(|line| format!("{}{}", indentation, line))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+impl Indent for String {
+    fn indent(&self, size: usize) -> String {
+        self.as_str().indent(size)
+    }
+}


### PR DESCRIPTION
### Summary

Implements the `fmt::Display` trait for `ERD` (and the other structs embedded in `ERD`) so that we can convert an ERD to a valid mermaid-compatible format using `to_string()` or `print!()` and its variations.

- Fixes: #1 
- Time to review: ~10 minutes

### Changes proposed

- Implements the `fmt::Display` trait for the following structs:
  - `erd::ERD`
  - `erd::entity::Entity`
  - `erd::entity::Attribute`
  - `erd::entity::KeyConstraints`
  - `erd::relationship::Relationship`
- Adds a new `utils` mod with an `Indent` trait and `append_items()` function

### Instructions for reviewer

Checkout the PR locally and review the behavior in the following tests in `src/erd/mod.rs`

- `display_erd_with_entities_and_their_attributes()`
- `display_erd_with_relationships()`
- `display_empty_diagram()`

Run the tests `cargo test --lib` and all tests should pass